### PR TITLE
fix database api call from trying to contact actual database

### DIFF
--- a/dbs_app/tests/tests_views/test_details_page.py
+++ b/dbs_app/tests/tests_views/test_details_page.py
@@ -53,7 +53,8 @@ class DBSDetailEntryTests(DBSTests):
 
         with mock.patch('nanny_models.dbs_check.DbsCheck.api.get_record') as nanny_api_get, \
                 mock.patch('nanny_models.dbs_check.DbsCheck.api.put'), \
-                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app:
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app, \
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.put'):
             nanny_api_get_app.return_value.status_code = 200
             self.sample_dbs['convictions'] = 'True'
             nanny_api_get_app.return_value.record = self.sample_app

--- a/dbs_app/tests/tests_views/test_details_page.py
+++ b/dbs_app/tests/tests_views/test_details_page.py
@@ -32,7 +32,8 @@ class DBSDetailEntryTests(DBSTests):
         """
         with mock.patch('nanny_models.dbs_check.DbsCheck.api.get_record') as nanny_api_get, \
                 mock.patch('nanny_models.dbs_check.DbsCheck.api.put'), \
-                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app:
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app, \
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.put'):
             nanny_api_get_app.return_value.status_code = 200
             nanny_api_get_app.return_value.record = self.sample_app
             nanny_api_get.return_value.status_code = 200

--- a/dbs_app/tests/tests_views/test_details_page.py
+++ b/dbs_app/tests/tests_views/test_details_page.py
@@ -4,7 +4,9 @@ import uuid
 from django.urls import resolve
 
 from ..tests import DBSTests, authenticate
-from ...views import *
+# from ...views import D
+from dbs_app import views
+from dbs_app.views import build_url
 
 
 @mock.patch("identity_models.user_details.UserDetails.api.get_record", authenticate)
@@ -53,8 +55,7 @@ class DBSDetailEntryTests(DBSTests):
 
         with mock.patch('nanny_models.dbs_check.DbsCheck.api.get_record') as nanny_api_get, \
                 mock.patch('nanny_models.dbs_check.DbsCheck.api.put'), \
-                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app, \
-                mock.patch('nanny_models.nanny_application.NannyApplication.api.put'):
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app:
             nanny_api_get_app.return_value.status_code = 200
             self.sample_dbs['convictions'] = 'True'
             nanny_api_get_app.return_value.record = self.sample_app
@@ -67,7 +68,7 @@ class DBSDetailEntryTests(DBSTests):
 
             # As this response can redirect to multiple places, the view which is rendered on redirect is checked below
             found = resolve(response.url)
-            self.assertEqual(found.func.view_class, DBSUpload)
+            self.assertEqual(found.func.view_class, views.DBSUpload)
             self.assertEqual(response.status_code, 302)
 
     def test_can_reject_incorrect_submission_without_convictions(self):

--- a/dbs_app/tests/tests_views/test_details_page.py
+++ b/dbs_app/tests/tests_views/test_details_page.py
@@ -55,7 +55,8 @@ class DBSDetailEntryTests(DBSTests):
 
         with mock.patch('nanny_models.dbs_check.DbsCheck.api.get_record') as nanny_api_get, \
                 mock.patch('nanny_models.dbs_check.DbsCheck.api.put'), \
-                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app:
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.get_record') as nanny_api_get_app, \
+                mock.patch('nanny_models.nanny_application.NannyApplication.api.put'):
             nanny_api_get_app.return_value.status_code = 200
             self.sample_dbs['convictions'] = 'True'
             nanny_api_get_app.return_value.record = self.sample_app


### PR DESCRIPTION
## Description

Put request for NannyApplication had not been mocked, this means that it would still try and contact the actual database when running tests.

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
