### PR TITLE
fix/nanny-start-page-css

### DIFF
--- a/login_app/templates/start-page.html
+++ b/login_app/templates/start-page.html
@@ -5,7 +5,7 @@
 
 {% block inner_content %}
 
-<div style="width: 150%">
+<div class="start-page-width">
 <div class="grid-row">
     <div class="column-two-thirds">
 

--- a/nanny/static/stylesheets/custom.css
+++ b/nanny/static/stylesheets/custom.css
@@ -462,6 +462,16 @@ div.error-summary ul.error-summary-list {
     }
 }
 
+.start-page-width {
+    width: 150%;
+}
+
+@media (max-width: 640px) {
+    .start-page-width {
+      width: 100%;
+    }
+}
+
 .list-bullet {
   margin-left: 20px !important;
 }


### PR DESCRIPTION
## Description

Fix nanny start page CSS for mobile devices - width now 100%.

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
