### PR TITLE
CCN3-1038 bug: Set correct email template if existing or new user

### DIFF
--- a/login_app/views/existing_user_sign_in.py
+++ b/login_app/views/existing_user_sign_in.py
@@ -41,10 +41,18 @@ class ExistingUserSignInFormView(BaseFormView):
         record['email_expiry_date'] = email_expiry_date
         UserDetails.api.put(record)
 
-        # Send Nanny email for existing users
+        # Set Nanny email template
+        # If existing user
+        if record['mobile_number'] != '':
+            template_id = '5d983266-7efa-4978-9d4c-9099ed6ece28'
+        # If new user
+        else:
+            template_id = '45c6b63e-1973-45e5-99d7-25f2877bebd9'
+
+        # Send Nanny email
         notify.send_email(email=email_address,
                           personalisation={"link": validation_link},
-                          template_id='5d983266-7efa-4978-9d4c-9099ed6ece28')
+                          template_id=template_id)
 
         return HttpResponseRedirect(self.get_success_url())
 

--- a/login_app/views/new_user_sign_in.py
+++ b/login_app/views/new_user_sign_in.py
@@ -41,10 +41,18 @@ class NewUserSignInFormView(BaseFormView):
         record['email_expiry_date'] = email_expiry_date
         UserDetails.api.put(record)
 
-        # Send Nanny login email for new users
+        # Set Nanny email template
+        # If existing user
+        if record['mobile_number'] != '':
+            template_id = '5d983266-7efa-4978-9d4c-9099ed6ece28'
+        # If new user
+        else:
+            template_id = '45c6b63e-1973-45e5-99d7-25f2877bebd9'
+
+        # Send Nanny email
         notify.send_email(email=email_address,
                           personalisation={"link": validation_link},
-                          template_id='45c6b63e-1973-45e5-99d7-25f2877bebd9')
+                          template_id=template_id)
 
         return HttpResponseRedirect(self.get_success_url())
 

--- a/login_app/views/resend_email.py
+++ b/login_app/views/resend_email.py
@@ -20,9 +20,17 @@ class ResendEmail(View):
         record['email_expiry_date'] = email_expiry_date
         UserDetails.api.put(record)
 
-        # Send a Nannies email
+        # Set Nanny email template
+        # If existing user
+        if record['mobile_number'] != '':
+            template_id = '5d983266-7efa-4978-9d4c-9099ed6ece28'
+        # If new user
+        else:
+            template_id = '45c6b63e-1973-45e5-99d7-25f2877bebd9'
+
+        # Send a Nanny email
         notify.send_email(email=email_address,
                           personalisation={"link": validation_link},
-                          template_id='5d983266-7efa-4978-9d4c-9099ed6ece28')
+                          template_id=template_id)
 
         return render(request, template_name='email-resent.html', context={'email_address': email_address})


### PR DESCRIPTION
## Description

The confirm email needs to be sent if the applicant has not yet provided their mobile number, regardless of whether they click 'Start new application', 'Go back to your application' or to resend their email. In this case, the user is considered a new user. Once the mobile number has been provided, the user is seen as an existing user and should be sent the sign in email, whether they click 'Start new application', 'Go back to your application' or to resend their email. Logic has been implemented to ensure this.

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
