### PR TITLE
fix/CCN3-1474/Nannies-childcare-address-back-button

### DIFF
--- a/nanny/db_gateways.py
+++ b/nanny/db_gateways.py
@@ -65,6 +65,8 @@ class DBGatewayActions:
     def delete(self, endpoint, params):
         if endpoint == 'arc-comments':
             return requests.delete(self.target_url_prefix + endpoint + '/' + params['review_id'] + '/', data=params)
+        if endpoint == 'childcare-address':
+            return requests.delete(self.target_url_prefix + endpoint + '/' + params['childcare_address_id'] + '/', data=params)
         else:
             return requests.delete(self.target_url_prefix + endpoint + '/' + params['application_id'] + '/', data=params)
 


### PR DESCRIPTION
## Description

Modified file: childcare_address_entry.py:

- Rewrote / created functions for returning the number of addresses and the ordinal of addresses to be displayed within the pages. This number follows various logic paths to determine if a user has already completed the journey, is using the back button to try and alter addresses and if it is their first time adding an address.
- Added functionality that removes any uncompleted applications when the address_details page is loaded. This prevents a user going back from the address lookup page and creating a 'ghost address' that is only populated with a postcode. This functionality works by looping through the existing addresses and appending the API list to only include those with a completed address, where first line of the address is populated. Before this, this was based on the presence of a postcode. 
- Added a flagging system that is activated by the use of the 'add another address' button on the address details page. When a user selects this, a flag is passed through the 'build_url' function and is then present for the postcode and address lookup page. This functionality is still causing issues as a user can:
    - complete their first address
    - select 'add another address'
    - complete their second address to the details page
    - use the back button twice to return to the postcode lookup page 
    - This will display the incorrect address number and ordinals

A possible fix for these issues may include creating a flag that shows the number of completed addresses instead of the Boolean flag that exists currently, although this can still cause further issues. 

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [ ] Selenium tests have passed
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [x] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
