### PR TITLE
fix/CCN3-1904/childcare address details back button

### DIFF
--- a/application/presentation/childcare_address/forms/childcare_location.py
+++ b/application/presentation/childcare_address/forms/childcare_location.py
@@ -20,7 +20,7 @@ class ChildcareLocationForm(NannyForm):
                                                    required=True,
                                                    widget=InlineRadioSelect,
                                                    error_messages={
-                                                       'required': "Please say if you'll work and live at the same address"}
+                                                       'required': "Please say if you live and work at the same address"}
                                                    )
 
     def __init__(self, *args, **kwargs):

--- a/application/presentation/childcare_address/views/childcare_location.py
+++ b/application/presentation/childcare_address/views/childcare_location.py
@@ -65,13 +65,13 @@ class ChildcareLocationView(NannyFormView):
             aha_api_response = NannyGatewayActions().read('applicant-home-address', params={'application_id': app_id})
 
             if aha_api_response.status_code == 200:
-
                 home_address_record = aha_api_response.record
+                initial_both_work_and_home_address = home_address_record['childcare_address']
                 home_address_record['childcare_address'] = both_work_and_home_address
                 NannyGatewayActions().put('applicant-home-address', params=home_address_record)
 
                 # add new childcare address
-                if both_work_and_home_address:
+                if both_work_and_home_address and not initial_both_work_and_home_address:
                     NannyGatewayActions().create(
                         'childcare-address',
                         params={


### PR DESCRIPTION
## Description

Fixing the childcare address section so that when the applicant goes back to the childcare location question, and they answer yes for a second time, a new childcare address is not added.

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [ ] Selenium tests have passed
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [ ] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
